### PR TITLE
:wrench: Infra/editorconfig and eslint-import

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,18 +12,19 @@
     "kisstkondoros.vscode-gutter-preview",
     "wix.vscode-import-cost",
     "oderwat.indent-rainbow",
-    "VisualStudioExptTeam.vscodeintellicode",
-    "VisualStudioExptTeam.intellicode-api-usage-examples",
-    "zhuangtongfa.Material-theme",
+    "visualstudioexptteam.vscodeintellicode",
+    "visualstudioexptteam.intellicode-api-usage-examples",
+    "zhuangtongfa.material-theme",
     "christian-kohler.path-intellisense",
     "esbenp.prettier-vscode",
     "rvest.vs-code-prettier-eslint",
     "yoavbls.pretty-ts-errors",
-    "Prisma.prisma",
+    "prisma.prisma",
     "bradlc.vscode-tailwindcss",
     "pflannery.vscode-versionlens",
-    "ZixuanChen.vitest-explorer",
+    "zixuanchen.vitest-explorer",
     "vscode-icons-team.vscode-icons",
-    "streetsidesoftware.code-spell-checker"
+    "streetsidesoftware.code-spell-checker",
+    "editorconfig.editorconfig"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "cSpell.words": [
     "ATDD",
     "Kakerlaken",
+    "preinstall",
     "swcrc",
     "Turborepo",
     "typecheck",
@@ -9,7 +10,5 @@
   ],
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
-  "editor.formatOnType": true,
-  "editor.tabSize": 2,
-  "prettier.endOfLine": "lf"
+  "editor.formatOnType": true
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "kakerlaken-poker",
   "private": true,
   "scripts": {
     "build": "turbo run build",
@@ -11,6 +12,13 @@
     "lint:fix": "turbo run lint:fix",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "preinstall": "npx only-allow pnpm"
+  },
+  "dependencies": {
+    "fp-ts": "^2.16.1",
+    "monocle-ts": "^2.3.13",
+    "next": "^13.4.19",
+    "ramda": "^0.29.0",
+    "ts-pattern": "^5.0.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.2",
@@ -27,13 +35,5 @@
     "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^0.34.3"
   },
-  "packageManager": "pnpm@8.6.10",
-  "name": "Kakerlaken-Poker",
-  "dependencies": {
-    "fp-ts": "^2.16.1",
-    "monocle-ts": "^2.3.13",
-    "next": "^13.4.19",
-    "ramda": "^0.29.0",
-    "ts-pattern": "^5.0.5"
-  }
+  "packageManager": "pnpm@8.6.10"
 }

--- a/packages/domain_layer/.eslintrc.js
+++ b/packages/domain_layer/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint/eslint-plugin'],
+  plugins: ['@typescript-eslint/eslint-plugin', 'import'],
   extends: [
     'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
@@ -22,5 +22,20 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'import/order': [
+      'error',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+          'unknown',
+        ],
+        'newlines-between': 'always',
+      },
+    ],
   },
 };

--- a/packages/domain_layer/package.json
+++ b/packages/domain_layer/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "fp-ts": "^2.16.1",
     "monocle-ts": "^2.3.13",
-    "ts-pattern": "^5.0.5",
-    "ramda": "0.29.0"
+    "ramda": "0.29.0",
+    "ts-pattern": "^5.0.5"
   },
   "devDependencies": {
     "@swc/cli": "^0.1.62",
@@ -32,6 +32,7 @@
     "eslint": "^8.42.0",
     "eslint-config-custom": "workspace:*",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.8",
     "source-map-support": "^0.5.21",

--- a/packages/domain_layer/src/card/createCard.test.ts
+++ b/packages/domain_layer/src/card/createCard.test.ts
@@ -1,5 +1,6 @@
-import { createCard } from './createCard';
 import O from 'fp-ts/Option';
+
+import { createCard } from './createCard';
 import { Creature, Status } from './type';
 
 describe('createCard', () => {
@@ -19,7 +20,7 @@ describe('createCard', () => {
   it(`
     given a creature
       creature is 'Bat'
-    when create card 
+    when create card
       the creature is valid
     then return Card
       creature is 'Bat'
@@ -38,7 +39,7 @@ describe('createCard', () => {
   it(`
     given a creature
       creature is 'Bat'
-    when create card 
+    when create card
       the creature is valid
       and initial status is unrevealed
     then return card
@@ -61,7 +62,7 @@ describe('createCard', () => {
   it(`
     given a creature
       creature is 'Cockroach'
-    when create card 
+    when create card
       the creature is valid
       and initial status is unrevealed
     then return card
@@ -83,7 +84,7 @@ describe('createCard', () => {
   it(`
     given a creature
       creature is 'Fly'
-    when create card 
+    when create card
       the creature is valid
       and initial status is unrevealed
     then return card

--- a/packages/domain_layer/src/game/deck/createDeck.test.ts
+++ b/packages/domain_layer/src/game/deck/createDeck.test.ts
@@ -1,4 +1,5 @@
 import { Creature } from 'card';
+
 import { createDeck } from './createDeck';
 
 describe('createDeck', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       eslint-config-prettier:
         specifier: ^8.8.0
         version: 8.10.0(eslint@8.49.0)
+      eslint-plugin-import:
+        specifier: ^2.28.1
+        version: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.49.0)(prettier@2.8.8)
@@ -2095,7 +2098,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.28.1)
       eslint-import-resolver-typescript: 3.6.0(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.28.1)(eslint@8.49.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.49.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)
       eslint-plugin-jest: 27.4.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.49.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.49.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.4.0)(eslint@8.49.0)
@@ -3644,7 +3647,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -3668,7 +3671,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.49.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
       is-core-module: 2.13.0
@@ -3710,6 +3713,35 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.49.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.62.0(eslint@8.49.0)(typescript@5.2.2)
+      debug: 3.2.7
+      eslint: 8.49.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-plugin-eslint-comments@3.2.0(eslint@8.49.0):
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
@@ -3721,7 +3753,7 @@ packages:
       ignore: 5.2.4
     dev: true
 
-  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0):
+  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.49.0):
     resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3731,7 +3763,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.49.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.49.0)(typescript@5.2.2)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -3740,7 +3772,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.49.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.49.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3


### PR DESCRIPTION
## Describe your changes

1. (root): add `.editorconfig` to setup `indent_size` and `end_of_line` instead of `.vscode` `settings.json` (for compatibility of other IDEs like `vim`, `nvim`, `webstorm`...).
2. (packages/domain_layer): add `eslint-plugin-import` to proper separate import by scopes.
3. (root): revise package.json to suit npm package rules. (`Kakerlaken-Poker` => `kakerlaken-poker`), and lint using [sort-package-json](https://www.npmjs.com/package/sort-package-json).

---

## What is the scope of this change?
- [x] **Root** // I think there should has a `Root` scope for `ci` or dependency change.

backend
- [x] **Domain**
- [ ] **Repository**
- [ ] **UseCase**
- [ ] **Api**

frontend
- [ ] **Ui**
- [ ] **Web**

