### PR TITLE
:heavy_plus_sign: add ts-reset for better typesafe

### DIFF
--- a/apps/api/src/reset.d.ts
+++ b/apps/api/src/reset.d.ts
@@ -1,0 +1,1 @@
+import '@total-typescript/ts-reset';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@next/eslint-plugin-next": "^13.4.19",
     "@testing-library/jest-dom": "^6.1.1",
     "@testing-library/react": "^14.0.0",
+    "@total-typescript/ts-reset": "^0.5.1",
     "@types/node": "^20.6.5",
     "@types/react": "^18.0.22",
     "@types/react-dom": "^18.0.7",

--- a/apps/web/reset.d.ts
+++ b/apps/web/reset.d.ts
@@ -1,0 +1,1 @@
+import "@total-typescript/ts-reset";

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.2",
     "@testing-library/react": "^14.0.0",
+    "@total-typescript/ts-reset": "^0.5.1",
     "@types/ramda": "^0.29.4",
     "@vitejs/plugin-react-swc": "^3.4.0",
     "@vitest/coverage-v8": "^0.34.5",

--- a/packages/domain_layer/src/reset.d.ts
+++ b/packages/domain_layer/src/reset.d.ts
@@ -1,0 +1,1 @@
+import '@total-typescript/ts-reset';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.1",
     "@testing-library/react": "^14.0.0",
+    "@total-typescript/ts-reset": "^0.5.1",
     "@turbo/gen": "^1.10.12",
     "@types/node": "^20.6.5",
     "@types/react": "^18.2.0",

--- a/packages/ui/reset.d.ts
+++ b/packages/ui/reset.d.ts
@@ -1,0 +1,1 @@
+import "@total-typescript/ts-reset";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@total-typescript/ts-reset':
+        specifier: ^0.5.1
+        version: 0.5.1
       '@types/node':
         specifier: ^20.6.5
         version: 20.6.5
@@ -290,6 +293,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@total-typescript/ts-reset':
+        specifier: ^0.5.1
+        version: 0.5.1
       '@turbo/gen':
         specifier: ^1.10.12
         version: 1.10.14(@types/node@20.6.5)(typescript@4.9.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@total-typescript/ts-reset':
+        specifier: ^0.5.1
+        version: 0.5.1
       '@types/ramda':
         specifier: ^0.29.4
         version: 0.29.4
@@ -1667,6 +1670,10 @@ packages:
 
   /@tootallnate/quickjs-emscripten@0.23.0:
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+    dev: true
+
+  /@total-typescript/ts-reset@0.5.1:
+    resolution: {integrity: sha512-AqlrT8YA1o7Ff5wPfMOL0pvL+1X+sw60NN6CcOCqs658emD6RfiXhF7Gu9QcfKBH7ELY2nInLhKSCWVoNL70MQ==}
     dev: true
 
   /@tsconfig/node10@1.0.9:


### PR DESCRIPTION
## Describe your changes

1. Add devDeps: "@total-typescript/ts-reset": "^0.5.1" at root
2. Add `reset.d.ts` at `domain_layer`

ts-reset provided better type safe for some situations.
```typescript
// normal JSON.parse
const a = JSON.parse(req) // any
// with ts-reset
const a = JSON.parse(req) // unknown
```

you can checkout [ts-reset npm](https://www.npmjs.com/package/@total-typescript/ts-reset) to find more features.

---

## What is the scope of this change?
- [x] **Root**

backend
- [x] **Domain**
- [ ] **Repository**
- [ ] **UseCase**
- [x] **Api**

frontend
- [x] **Ui**
- [x] **Web**

